### PR TITLE
Update docker-compose.yml of monitoring section

### DIFF
--- a/data-validator/monitoring/docker-compose.yml
+++ b/data-validator/monitoring/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3.8"
 
 networks:
   eo-data-validator:
-    name: eo-data-validator
-    driver: bridge
+    external: true
   monitoring:
     name: monitoring
     driver: bridge


### PR DESCRIPTION
The `eo-data-validator` network already created by `data-validator`. No need to create it again because it conflicts with the other one.